### PR TITLE
Have the source found where it is defined in the beam when default search fails.

### DIFF
--- a/org.erlide.kernel.debugger.otp.r16/src/int.erl
+++ b/org.erlide.kernel.debugger.otp.r16/src/int.erl
@@ -167,8 +167,8 @@ interpretable(AbsMod) ->
 %%--------------------------------------------------------------------
 interpretable(AbsMod, Options) when is_list(Options) ->
     case check(AbsMod, Options) of
-    {ok, _Res} -> true;
-    Error -> Error
+	{ok, _Res} -> true;
+	Error -> Error
     end.
 
 %%--------------------------------------------------------------------
@@ -624,22 +624,39 @@ check_application2("debugger-"++_) -> throw({error,{app,debugger}});
 check_application2(_) -> ok.
 
 find_src(Beam, Options) ->
-    Src0 = filename:rootname(Beam) ++ ".erl",
-    case is_file(Src0) of
-	true -> Src0;
-	false ->
-	    EbinDir = filename:dirname(Beam),
-        SrcDirs = proplists:get_value(src_dirs, Options, ["src"]),
-            Fun = fun(Dir, Acc) ->
-                          Src = filename:join([filename:dirname(EbinDir), Dir,
-				 filename:basename(Src0)]),
-	    case is_file(Src) of
-		true -> Src;
-                              false -> Acc
-	    end
-                  end,
-            lists:foldl(Fun, error, SrcDirs)
-    end.
+	Src0 = filename:rootname(Beam) ++ ".erl",
+	case is_file(Src0) of
+		true -> Src0;
+		false ->
+			EbinDir = filename:dirname(Beam),
+			SrcDirs = proplists:get_value(src_dirs, Options, ["src"]),
+			Fun = fun(Dir, Acc) ->
+						  Src = filename:join([filename:dirname(EbinDir), Dir,
+											   filename:basename(Src0)]),
+						  case is_file(Src) of
+							  true -> Src;
+							  false -> Acc
+						  end
+				  end,
+			case lists:foldl(Fun, error, SrcDirs) of
+				error ->
+					Base = list_to_atom(filename:basename(filename:rootname(Beam))),
+					case proplists:get_value(source,Base:module_info(compile)) of
+						undefined ->
+							error;
+						FoundSrc ->
+							case is_file(FoundSrc) of
+								true ->
+									FoundSrc;
+								false ->
+									error
+							end
+					end;
+				FoundSrc ->
+					FoundSrc
+			end
+	end
+.
 
 find_beam(Mod, Src, Options) ->
     SrcDir = filename:dirname(Src),


### PR DESCRIPTION
When debugging, finding the source on the connected node does not care about the information that is in the beam file. When working with large projects having several applications with different subdirectories, giving the absolute path in the sources input box is a nightmare. The change allows finding the original source that is saved in the beam file, when the original method (same, directory, sources path, etc) do not find it.